### PR TITLE
fix: SessionStart hook ticket prompt now works in interactive sessions

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-dev-insights",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Developer analytics and productivity insights for Claude Code. Automatically tracks session analytics, enforces security policies, guards against cost overruns, and ensures code quality with 4 intelligent hooks: SessionEnd, SessionStart, PreToolUse, and PostToolUse.",
   "author": {
     "name": "Kanopi Studios",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.1] - 2025-11-14
+
+### Fixed
+- **SessionStart Hook** - Fixed ticket number prompt not appearing during interactive sessions
+  - Changed stdin check `[ -t 0 ]` to stdout check `[ -t 1 ]` at hooks/session-start/session-start.sh:73
+  - Modified `read` command to read from `/dev/tty` instead of stdin at hooks/session-start/session-start.sh:76
+  - The hook now correctly prompts users for ticket numbers even when stdin contains JSON input from Claude Code
+
+### Technical Details
+- The issue occurred because stdin was already consumed by the `cat` command that reads hook input JSON
+- Reading from `/dev/tty` allows interactive prompts even when stdin is redirected or exhausted
+- This is the standard solution for scripts that need both piped input and interactive user prompts
+
 ## [1.1.0] - 2025-11-14
 
 ### Added

--- a/hooks/session-start/session-start.sh
+++ b/hooks/session-start/session-start.sh
@@ -70,10 +70,10 @@ user_name=$(echo "$user_name" | sed 's/,/-/g' | sed 's/"//g')
 
 # Prompt for optional ticket number
 ticket_number=""
-if [ -t 0 ]; then
-    # Only prompt if running interactively (stdin is a terminal)
+if [ -t 1 ]; then
+    # Only prompt if stdout is a terminal (user can interact)
     echo "Enter ticket number (optional, press Enter to skip): " >&2
-    read -r ticket_number
+    read -r ticket_number < /dev/tty
     ticket_number=$(echo "$ticket_number" | sed 's/,/-/g' | sed 's/"//g' | xargs)
 fi
 


### PR DESCRIPTION
## Description
Teamwork Ticket(s): [Bug Fix - SessionStart Hook Ticket Prompt](insert_link_here)
- [x] Was AI used in this pull request?

> As a developer, I need the SessionStart hook to properly prompt me for ticket numbers during interactive Claude Code sessions.

This PR fixes a bug in the SessionStart hook where the ticket number prompt was never appearing during interactive sessions. The issue was caused by stdin being consumed by the initial JSON input parsing, and then the terminal check failing because stdin was no longer available as a terminal device.

**Current behavior:** The ticket number prompt never appears during Claude Code sessions, and the ticket_number field remains empty in session logs.

**Updated behavior:** Users are now properly prompted to enter a ticket number (optional) when starting a Claude Code session, and their input is correctly captured and stored in the session context.

## Acceptance Criteria
* The SessionStart hook successfully prompts users for a ticket number when a Claude Code session starts
* The prompt appears even when stdin contains JSON input from Claude Code
* User input is correctly captured and sanitized for CSV storage
* The ticket number is stored in the session context file for SessionEnd to reference
* Interactive prompts only appear when stdout is a terminal (not during non-interactive runs)

## Assumptions
* This fix assumes users are running Claude Code in an interactive terminal environment
* The `/dev/tty` device is available on the user's system (standard on macOS/Linux)
* The fix maintains backward compatibility with existing session logging functionality

## Steps to Validate
1. Start a new Claude Code session in a project with this plugin installed
2. Observe the SessionStart hook output - you should see the session context display
3. You should be prompted with: "Enter ticket number (optional, press Enter to skip):"
4. Enter a ticket number (e.g., "PROJ-123") or press Enter to skip
5. Check the session context file: `cat ~/.claude/session-logs/.session-start-<session_id>`
6. Verify the `ticket_number` field contains your input (or is empty if skipped)
7. Complete the session and verify the ticket number appears in the sessions.csv file

## Affected URL
N/A - This is a CLI plugin, no web interface

## Deploy Notes

**Changes:**
- Modified `hooks/session-start/session-start.sh` (2 lines changed)
- Updated `.claude-plugin/plugin.json` version to 1.1.1
- Added CHANGELOG.md entry for version 1.1.1

**Technical Changes:**
- Line 73: Changed `[ -t 0 ]` (stdin check) to `[ -t 1 ]` (stdout check)
- Line 76: Changed `read -r ticket_number` to `read -r ticket_number < /dev/tty`

**Deployment Requirements:**
- No new dependencies
- No configuration changes required
- Plugin version bump from 1.1.0 to 1.1.1
- Users should update via Claude Code plugin marketplace or git pull

**Post-Deployment:**
- Test in an interactive session to confirm prompt appears
- Verify ticket numbers are being captured in session logs