### PR TITLE
fix: Handle combined ticket and summary commands in any order

### DIFF
--- a/hooks/user-prompt-submit/user-prompt-submit.sh
+++ b/hooks/user-prompt-submit/user-prompt-submit.sh
@@ -18,7 +18,86 @@ mkdir -p "$log_dir"
 # Session start context file
 start_context_file="$log_dir/.session-start-${session_id}"
 
-# Check if this is a ticket: command
+# Check if this message contains both ticket: and summary: commands (order-agnostic)
+if echo "$prompt" | grep -qiE 'ticket:' && echo "$prompt" | grep -qiE 'summary:'; then
+    # Determine which comes first
+    if echo "$prompt" | grep -qiE '^ticket:\s*.*summary:\s*'; then
+        # ticket: comes first, then summary:
+        new_tickets=$(echo "$prompt" | sed -E 's|^ticket:\s*||i' | sed -E 's|\s*summary:.*||i' | xargs)
+        new_summary=$(echo "$prompt" | sed -E 's|^.*summary:\s*||i' | xargs)
+    elif echo "$prompt" | grep -qiE '^summary:\s*.*ticket:\s*'; then
+        # summary: comes first, then ticket:
+        new_summary=$(echo "$prompt" | sed -E 's|^summary:\s*||i' | sed -E 's|\s*ticket:.*||i' | xargs)
+        new_tickets=$(echo "$prompt" | sed -E 's|^.*ticket:\s*||i' | xargs)
+    else
+        # Both exist but not at the start - extract both
+        new_tickets=$(echo "$prompt" | grep -oiE 'ticket:\s*[^s]*' | sed -E 's|ticket:\s*||i' | sed -E 's|\s*summary:.*||i' | xargs)
+        new_summary=$(echo "$prompt" | grep -oiE 'summary:\s*.*' | sed -E 's|summary:\s*||i' | sed -E 's|\s*ticket:.*||i' | xargs)
+    fi
+
+    if [ -n "$new_tickets" ] || [ -n "$new_summary" ]; then
+        # Get existing tickets if any
+        existing_tickets=""
+        if [ -f "$start_context_file" ]; then
+            existing_tickets=$(jq -r '.ticket_number // ""' "$start_context_file" 2>/dev/null)
+        fi
+
+        # Combine existing and new tickets
+        if [ -n "$new_tickets" ]; then
+            if [ -n "$existing_tickets" ]; then
+                all_tickets="$existing_tickets $new_tickets"
+            else
+                all_tickets="$new_tickets"
+            fi
+        else
+            all_tickets="$existing_tickets"
+        fi
+
+        # Update or create context file with both ticket and summary
+        if [ -f "$start_context_file" ]; then
+            temp_file=$(mktemp)
+            if [ -n "$all_tickets" ] && [ -n "$new_summary" ]; then
+                jq --arg tickets "$all_tickets" --arg summary "$new_summary" \
+                   '.ticket_number = $tickets | .summary = $summary' \
+                   "$start_context_file" > "$temp_file"
+            elif [ -n "$all_tickets" ]; then
+                jq --arg tickets "$all_tickets" '.ticket_number = $tickets' "$start_context_file" > "$temp_file"
+            elif [ -n "$new_summary" ]; then
+                jq --arg summary "$new_summary" '.summary = $summary' "$start_context_file" > "$temp_file"
+            fi
+            mv "$temp_file" "$start_context_file"
+        else
+            # Create new context file
+            cat > "$start_context_file" <<EOF
+{
+  "session_id": "$session_id",
+  "ticket_number": "$all_tickets",
+  "summary": "$new_summary",
+  "start_timestamp": "$(date '+%Y-%m-%d %H:%M:%S')"
+}
+EOF
+        fi
+
+        # Output confirmation
+        echo "⏺ I've captured your session metadata:"
+        echo ""
+        if [ -n "$all_tickets" ]; then
+            echo "  - Ticket: $all_tickets"
+        fi
+        if [ -n "$new_summary" ]; then
+            echo "  - Summary: $new_summary"
+        fi
+        echo ""
+        echo "  This information will be automatically logged to your session CSV"
+        echo "  (~/.claude/session-logs/sessions.csv) when the session ends, making it"
+        echo "  easy to track your work and generate reports."
+
+        # Exit successfully - combined command handled
+        exit 0
+    fi
+fi
+
+# Check if this is a ticket: command (without summary)
 if echo "$prompt" | grep -qiE '^ticket:\s*'; then
     # Extract ticket numbers from the command
     new_tickets=$(echo "$prompt" | sed -E 's|^ticket:\s*||i' | xargs)
@@ -63,7 +142,7 @@ EOF
     fi
 fi
 
-# Check if this is a summary: command
+# Check if this is a summary: command (without ticket)
 if echo "$prompt" | grep -qiE '^summary:\s*'; then
     # Extract summary text from the command
     new_summary=$(echo "$prompt" | sed -E 's|^summary:\s*||i' | xargs)

--- a/tests/test-plugin.bats
+++ b/tests/test-plugin.bats
@@ -432,6 +432,82 @@ setup() {
   grep -q '.summary' hooks/session-end/session-end.sh
 }
 
+@test "user-prompt-submit handles combined ticket and summary command" {
+  # Create a temporary log directory and session context
+  temp_log_dir=$(mktemp -d)
+  session_id="test-session-$$"
+
+  # Create input JSON with combined command (ticket first)
+  input_json=$(cat <<EOF
+{
+  "session_id": "$session_id",
+  "prompt": "ticket: JIRA-12345 summary: Fix authentication bug",
+  "cwd": "$PWD"
+}
+EOF
+)
+
+  # Override log directory for this test
+  (
+    export HOME="$temp_log_dir"
+    mkdir -p "$temp_log_dir/.claude/session-logs"
+
+    # Run the hook
+    echo "$input_json" | bash hooks/user-prompt-submit/user-prompt-submit.sh
+
+    # Check that both ticket and summary were stored
+    context_file="$temp_log_dir/.claude/session-logs/.session-start-${session_id}"
+    [ -f "$context_file" ]
+
+    ticket=$(jq -r '.ticket_number // ""' "$context_file")
+    summary=$(jq -r '.summary // ""' "$context_file")
+
+    [ "$ticket" = "JIRA-12345" ]
+    [ "$summary" = "Fix authentication bug" ]
+  )
+
+  # Cleanup
+  rm -rf "$temp_log_dir"
+}
+
+@test "user-prompt-submit handles reverse order (summary then ticket)" {
+  # Test that summary: first, ticket: second also works
+  temp_log_dir=$(mktemp -d)
+  session_id="test-reverse-$$"
+
+  # Create input JSON with summary first, ticket second
+  input_json=$(cat <<EOF
+{
+  "session_id": "$session_id",
+  "prompt": "summary: Refactoring the authentication module ticket: PROJ-999",
+  "cwd": "$PWD"
+}
+EOF
+)
+
+  # Override log directory for this test
+  (
+    export HOME="$temp_log_dir"
+    mkdir -p "$temp_log_dir/.claude/session-logs"
+
+    # Run the hook
+    echo "$input_json" | bash hooks/user-prompt-submit/user-prompt-submit.sh
+
+    # Check that both ticket and summary were stored correctly
+    context_file="$temp_log_dir/.claude/session-logs/.session-start-${session_id}"
+    [ -f "$context_file" ]
+
+    ticket=$(jq -r '.ticket_number // ""' "$context_file")
+    summary=$(jq -r '.summary // ""' "$context_file")
+
+    [ "$ticket" = "PROJ-999" ]
+    [ "$summary" = "Refactoring the authentication module" ]
+  )
+
+  # Cleanup
+  rm -rf "$temp_log_dir"
+}
+
 @test "session-end hook extracts model from transcript" {
   # Test that session-end extracts the AI model from the transcript
   grep -q 'model=' hooks/session-end/session-end.sh


### PR DESCRIPTION
## Description
Teamwork Ticket(s): N/A (Internal bug fix)
- [x] Was AI used in this pull request?

> As a developer using the `ticket:` and `summary:` commands, I need them to work correctly when combined in a single message, regardless of which order I type them.

Previously, when users typed `ticket: 12345 summary: the name of the ticket`, the parser would capture the entire string after `ticket:` as the ticket number (including the `summary:` part), and the summary field would be left empty. Additionally, the reverse order (`summary: ... ticket: ...`) didn't work at all.

This PR fixes the parsing logic to handle both commands when combined in a single message, and makes the parsing order-agnostic so users can type the commands in either order naturally.

## Acceptance Criteria
* Typing `ticket: 12345 summary: Fix auth bug` correctly parses both values
* Typing `summary: Fix auth bug ticket: 12345` also correctly parses both values (reverse order)
* Individual commands (`ticket: 12345` alone or `summary: Fix auth bug` alone) continue to work as before
* Multiple tickets in combined syntax work: `ticket: JIRA-123 JIRA-456 summary: Working on multiple issues`
* Both ticket number and summary are correctly stored in the session context file
* Session CSV receives both values when the session ends

## Assumptions
* The fix maintains backward compatibility with existing single-command usage
* Users don't need to update their habits - both orderings are supported
* All 67 tests pass, including two new tests for combined command scenarios

## Steps to Validate
1. Install the updated plugin in your Claude Code environment
2. Start a new session and type: `ticket: TEST-123 summary: Testing combined commands`
3. Verify you see the confirmation message showing both values captured
4. End the session and check `~/.claude/session-logs/sessions.csv` - both fields should be populated
5. Start another session and try reverse order: `summary: Testing reverse order ticket: TEST-456`
6. Verify both values are captured correctly again
7. Test individual commands still work: `ticket: TEST-789` (alone) and `summary: Just a summary` (alone)
8. Run the test suite: `bats tests/test-plugin.bats` - all 67 tests should pass

## Affected URL
N/A (CLI plugin, no web interface)

## Deploy Notes
No special deployment steps required. Users just need to pull the latest version of the plugin. No configuration changes, database migrations, or dependency updates needed.

**Files Changed:**
- `hooks/user-prompt-submit/user-prompt-submit.sh` - Updated parsing logic to handle combined commands order-agnostically
- `tests/test-plugin.bats` - Added two new test cases for combined command scenarios (ticket-first and summary-first)